### PR TITLE
fix: default export CircularSlider

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ React Native component for creating circular slider.
 Import Circular Slider
 
 ```js
-import { CircularSlider } from 'react-native-circular-slider';
+import CircularSlider from 'react-native-circular-slider';
 ```
 
 Use as follows:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-circular-slider",
   "version": "1.0.0",
   "description": "React Native component for creating circular slider",
-  "main": "index.js",
+  "main": "src/CircularSlider.js",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/bgryszko/react-native-circular-slider.git"


### PR DESCRIPTION
After trying the example, I noticed CircularSlider was not exported.
I fixed that by adapting main property in `package.json`.
I also adapted the README to align on default import instead of named.