### PR TITLE
Fix center point calculation & Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
   "dependencies": {
     "d3-interpolate": "^1.1.2",
     "lodash.range": "^3.2.0",
-    "react-native-svg": ">=4.3.3"
+    "react-native-svg": "^5.1.5"
+  },
+  "peerDependencies": {
+    "react-native": ">=0.40.0",
+    "react": ">=15.4.0"
   }
 }

--- a/src/CircularSlider.js
+++ b/src/CircularSlider.js
@@ -82,7 +82,7 @@ export default class CircularSlider extends PureComponent {
     this._sleepPanResponder = PanResponder.create({
       onMoveShouldSetPanResponder: (evt, gestureState) => true,
       onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
-
+      onPanResponderGrant: (evt, gestureState) => this.setCircleCenter(),
       onPanResponderMove: (evt, { moveX, moveY }) => {
         const { circleCenterX, circleCenterY } = this.state;
         const { angleLength, startAngle, onUpdate } = this.props;
@@ -107,7 +107,7 @@ export default class CircularSlider extends PureComponent {
     this._wakePanResponder = PanResponder.create({
       onMoveShouldSetPanResponder: (evt, gestureState) => true,
       onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
-
+      onPanResponderGrant: (evt, gestureState) => this.setCircleCenter(),
       onPanResponderMove: (evt, { moveX, moveY }) => {
         const { circleCenterX, circleCenterY } = this.state;
         const { angleLength, startAngle, onUpdate } = this.props;
@@ -129,7 +129,7 @@ export default class CircularSlider extends PureComponent {
   }
 
   setCircleCenter = () => {
-    this._circle.measure((x, y, w, h, px , py) => {
+    this._circle.measure((x, y, w, h, px, py) => {
       const halfOfContainer = this.getContainerWidth() / 2;
       this.setState({ circleCenterX: px + halfOfContainer, circleCenterY: py + halfOfContainer });
     });

--- a/src/CircularSlider.js
+++ b/src/CircularSlider.js
@@ -244,17 +244,12 @@ export default class CircularSlider extends PureComponent {
               transform={{ translate: `${start.fromX}, ${start.fromY}` }}
               {...startProps}
             >
-              {
-                // Hide the icon circle if we have a fixed start position and no icon
-                !this.props.fixedStart || startIcon ? (
-                  <Circle
-                    r={(strokeWidth - 1) / 2}
-                    fill={bgCircleColor}
-                    stroke={gradientColorFrom}
-                    strokeWidth="1"
-                  />
-                ) : false
-              }
+              <Circle
+                r={(strokeWidth - 1) / 2}
+                fill={!this.props.fixedStart || startIcon ? bgCircleColor : gradientColorFrom}
+                stroke={gradientColorFrom}
+                strokeWidth="1"
+              />
               {
                 startIcon
               }

--- a/src/CircularSlider.js
+++ b/src/CircularSlider.js
@@ -215,27 +215,6 @@ export default class CircularSlider extends PureComponent {
             }
 
             {/*
-              ##### Stop Icon
-            */}
-
-            <G
-              fill={gradientColorTo}
-              transform={{ translate: `${stop.toX}, ${stop.toY}` }}
-              onPressIn={() => this.setState({ angleLength: angleLength + Math.PI / 2 })}
-              {...this._wakePanResponder.panHandlers}
-            >
-              <Circle
-                r={(strokeWidth - 1) / 2}
-                fill={bgCircleColor}
-                stroke={gradientColorTo}
-                strokeWidth="1"
-              />
-              {
-                stopIcon
-              }
-            </G>
-
-            {/*
               ##### Start Icon
             */}
 
@@ -254,6 +233,28 @@ export default class CircularSlider extends PureComponent {
                 startIcon
               }
             </G>
+
+            {/*
+             ##### Stop Icon
+             */}
+
+            <G
+              fill={gradientColorTo}
+              transform={{ translate: `${stop.toX}, ${stop.toY}` }}
+              onPressIn={() => this.setState({ angleLength: angleLength + Math.PI / 2 })}
+              {...this._wakePanResponder.panHandlers}
+            >
+              <Circle
+                r={(strokeWidth - 1) / 2}
+                fill={bgCircleColor}
+                stroke={gradientColorTo}
+                strokeWidth="1"
+              />
+              {
+                stopIcon
+              }
+            </G>
+
           </G>
         </Svg>
       </View>

--- a/src/CircularSlider.js
+++ b/src/CircularSlider.js
@@ -61,6 +61,7 @@ export default class CircularSlider extends PureComponent {
     bgCircleColor: PropTypes.string,
     stopIcon: PropTypes.element,
     startIcon: PropTypes.element,
+    fixedStart: PropTypes.bool
   }
 
   static defaultProps = {
@@ -71,6 +72,7 @@ export default class CircularSlider extends PureComponent {
     gradientColorTo: '#ffcf00',
     clockFaceColor: '#9d9d9d',
     bgCircleColor: '#171717',
+    fixedStart: false
   }
 
   state = {
@@ -148,6 +150,11 @@ export default class CircularSlider extends PureComponent {
 
     const start = calculateArcCircle(0, segments, radius, startAngle, angleLength);
     const stop = calculateArcCircle(segments - 1, segments, radius, startAngle, angleLength);
+
+    const startProps = !this.props.fixedStart ? {
+      onPressIn: () => this.setState({ startAngle: startAngle - Math.PI / 2, angleLength: angleLength + Math.PI / 2 }),
+      ...this._sleepPanResponder.panHandlers
+    } : {};
 
     return (
       <View style={{ width: containerWidth, height: containerWidth }} onLayout={this.onLayout}>
@@ -235,15 +242,19 @@ export default class CircularSlider extends PureComponent {
             <G
               fill={gradientColorFrom}
               transform={{ translate: `${start.fromX}, ${start.fromY}` }}
-              onPressIn={() => this.setState({ startAngle: startAngle - Math.PI / 2, angleLength: angleLength + Math.PI / 2 })}
-              {...this._sleepPanResponder.panHandlers}
+              {...startProps}
             >
-              <Circle
-                r={(strokeWidth - 1) / 2}
-                fill={bgCircleColor}
-                stroke={gradientColorFrom}
-                strokeWidth="1"
-              />
+              {
+                // Hide the icon circle if we have a fixed start position and no icon
+                !this.props.fixedStart || startIcon ? (
+                  <Circle
+                    r={(strokeWidth - 1) / 2}
+                    fill={bgCircleColor}
+                    stroke={gradientColorFrom}
+                    strokeWidth="1"
+                  />
+                ) : false
+              }
               {
                 startIcon
               }


### PR DESCRIPTION
Here's a solution to #7 - Trigger center point calculation when panning starts, as onLayout seems to fire too early in newer `react-native` versions resulting in an incorrect `px`. I've updated the `react-native-svg` dependency so that the example should compile as well.