### PR TITLE
Calculate circle center when dragging starts & Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
   "dependencies": {
     "d3-interpolate": "^1.1.2",
     "lodash.range": "^3.2.0",
-    "react-native-svg": ">=4.3.3"
+    "react-native-svg": "^5.1.5"
+  },
+  "peerDependencies": {
+    "react-native": ">=0.40.0",
+    "react": ">=15.4.0"
   }
 }

--- a/src/CircularSlider.js
+++ b/src/CircularSlider.js
@@ -82,7 +82,7 @@ export default class CircularSlider extends PureComponent {
     this._sleepPanResponder = PanResponder.create({
       onMoveShouldSetPanResponder: (evt, gestureState) => true,
       onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
-
+      onPanResponderGrant: (evt, gestureState) => this.setCircleCenter(),
       onPanResponderMove: (evt, { moveX, moveY }) => {
         const { circleCenterX, circleCenterY } = this.state;
         const { angleLength, startAngle, onUpdate } = this.props;
@@ -107,7 +107,7 @@ export default class CircularSlider extends PureComponent {
     this._wakePanResponder = PanResponder.create({
       onMoveShouldSetPanResponder: (evt, gestureState) => true,
       onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
-
+      onPanResponderGrant: (evt, gestureState) => this.setCircleCenter(),
       onPanResponderMove: (evt, { moveX, moveY }) => {
         const { circleCenterX, circleCenterY } = this.state;
         const { angleLength, startAngle, onUpdate } = this.props;
@@ -129,7 +129,7 @@ export default class CircularSlider extends PureComponent {
   }
 
   setCircleCenter = () => {
-    this._circle.measure((x, y, w, h, px , py) => {
+    this._circle.measure((x, y, w, h, px, py) => {
       const halfOfContainer = this.getContainerWidth() / 2;
       this.setState({ circleCenterX: px + halfOfContainer, circleCenterY: py + halfOfContainer });
     });


### PR DESCRIPTION
Here's a solution to #7 - Trigger center point calculation when panning starts, as onLayout seems to fire too early in newer `react-native` versions resulting in an incorrect `px`. I've updated the `react-native-svg` dependency so that the example should compile as well.