### PR TITLE
Update CircularSlider.js

### DIFF
--- a/src/CircularSlider.js
+++ b/src/CircularSlider.js
@@ -175,7 +175,7 @@ export default class CircularSlider extends PureComponent {
             ##### Circle
           */}
 
-          <G transform={{ translate: `${strokeWidth/2 + radius + 1}, ${strokeWidth/2 + radius + 1}` }}>
+          <G transform={`translate(${strokeWidth/2 + radius + 1}, ${strokeWidth/2 + radius + 1})`}>
             <Circle
               r={radius}
               strokeWidth={strokeWidth}
@@ -213,7 +213,7 @@ export default class CircularSlider extends PureComponent {
 
             <G
               fill={gradientColorTo}
-              transform={{ translate: `${stop.toX}, ${stop.toY}` }}
+              transform={`translate(${stop.toX}, ${stop.toY})`}
               onPressIn={() => this.setState({ angleLength: angleLength + Math.PI / 2 })}
               {...this._wakePanResponder.panHandlers}
             >
@@ -234,7 +234,7 @@ export default class CircularSlider extends PureComponent {
 
             <G
               fill={gradientColorFrom}
-              transform={{ translate: `${start.fromX}, ${start.fromY}` }}
+              transform={`translate(${start.fromX}, ${start.fromY})`}
               onPressIn={() => this.setState({ startAngle: startAngle - Math.PI / 2, angleLength: angleLength + Math.PI / 2 })}
               {...this._sleepPanResponder.panHandlers}
             >


### PR DESCRIPTION
Fixing breaking change with react-native-svg 's transform interpolation (object syntax has been removed)
As per:
https://github.com/react-native-community/react-native-svg/pull/507